### PR TITLE
docs: Adds Charmhub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-# httpreq-acme-operator
-
-## Description
+# httpreq ACME Operator (K8s)
+[![CharmHub Badge](https://charmhub.io/httpreq-acme-operator/badge.svg)](https://charmhub.io/httpreq-acme-operator)
 
 ACME operator implementing the provider side of the `tls-certificates`
 interface to get signed certificates from the `Let's Encrypt` ACME server


### PR DESCRIPTION
# Description

The Telco charms currently have broken statuses in the [charm engineering page](https://releases.juju.is/?team=Telco). This PR adds the appropriate charmhub badge to address this.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
